### PR TITLE
Port to pyca/cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyOpenSSL>=19.0.0
+cryptography>=41.0.0

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(name="https.server",
       packages=["https"],
       entry_points={"console_scripts": ["https.server = https.server:main"]},
       include_package_data=True,
-      install_requires=["pyOpenSSL>=19.0.0"],
+      install_requires=["cryptography>=41.0.0"],
       python_requires=">=3.6")


### PR DESCRIPTION
Using pyOpenSSL for generating certificates is deprecated and moving to [pyca/cryptography](https://github.com/pyca/cryptography) instead is recommended. See the note at the beginning of the [PyOpenSSL README](https://github.com/pyca/pyopenssl/blob/main/README.rst).

The new API in pyca/cryptography is more strongly typed so some changes to the cert generation code were necessary, but the result should be the same.